### PR TITLE
importer.py: Add gcc deoptimization attribute for Rizin CI ASAN build

### DIFF
--- a/importer.py
+++ b/importer.py
@@ -1852,8 +1852,17 @@ def write_files_rizin(ins_class, ins_duplex, hex_insn_names, extendable_insn):
     includes += ["extern ut32 constant_extender;"]
     includes += [""] # for the sake of beauty
 
+    # Add gcc deoptimization attribute for Rizin CI ASAN build
+    deoptimize_if_asan = ["#if ASAN"]
+    deoptimize_if_asan += ["#define NO_OPT_IF_ASAN __attribute__((optimize(0)))"]
+    deoptimize_if_asan += ["#else"]
+    deoptimize_if_asan += ["#define NO_OPT_IF_ASAN"]
+    deoptimize_if_asan += ["#endif"]
+    deoptimize_if_asan += [""] # for the sake of beauty
+
     # Wrap everything into one function
-    lines = auto_header + spdx + includes + make_C_block(lines, "int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr)", None, "return 4;")
+    lines = auto_header + spdx + includes + deoptimize_if_asan + \
+        make_C_block(lines, "NO_OPT_IF_ASAN int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr)", None, "return 4;")
     with open(HEX_DISAS_FILENAME, "w") as f:
         for l in lines:
             f.write(l + "\n")


### PR DESCRIPTION
This pr adds a gcc deoptimization attribute for the Rizin CI ASAN build (as used in https://github.com/rizinorg/rizin/commit/7a4f9b32012f0e779981cac789b85065781cf603#diff-27dd67668349a3768b22ece45c8945afa47406af80832db90df3093e0b925cad) in `importer.py`.