### PR TITLE
Add missing RZ_API in declaration.

### DIFF
--- a/handwritten/hexagon_disas_c/functions.c
+++ b/handwritten/hexagon_disas_c/functions.c
@@ -5,3 +5,4 @@ static inline bool is_last_instr(const ut8 parse_bits) {
 	// Duplex instr. (parse bits = 0) are always the last.
 	return ((parse_bits == 0x3) || (parse_bits == 0x0));
 }
+

--- a/handwritten/hexagon_h/declarations.h
+++ b/handwritten/hexagon_h/declarations.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2021 Rot127 <unisono@quyllur.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-void hex_extend_op(HexState *state, RZ_INOUT HexOp *op, const bool set_new_extender, const ut32 addr);
+RZ_API void hex_extend_op(HexState *state, RZ_INOUT HexOp *op, const bool set_new_extender, const ut32 addr);
 int resolve_n_register(const int reg_num, const ut32 addr, const HexPkt *p);
 int hexagon_disasm_instruction(const RzAsm *rz_asm, HexState *state, const ut32 hi_u32, RZ_INOUT HexInsn *hi, HexPkt *pkt);
 void hexagon_disasm_0x0(const RzAsm *rz_asm, HexState *state, const ut32 hi_u32, RZ_INOUT HexInsn *hi, const ut32 addr, HexPkt *pkt);

--- a/rizin/librz/asm/arch/hexagon/hexagon.h
+++ b/rizin/librz/asm/arch/hexagon/hexagon.h
@@ -547,7 +547,7 @@ char *hex_get_pred_regs(int opcode_reg);
 char *hex_get_sys_regs(int opcode_reg);
 char *hex_get_sys_regs64(int opcode_reg);
 
-void hex_extend_op(HexState *state, RZ_INOUT HexOp *op, const bool set_new_extender, const ut32 addr);
+RZ_API void hex_extend_op(HexState *state, RZ_INOUT HexOp *op, const bool set_new_extender, const ut32 addr);
 int resolve_n_register(const int reg_num, const ut32 addr, const HexPkt *p);
 int hexagon_disasm_instruction(const RzAsm *rz_asm, HexState *state, const ut32 hi_u32, RZ_INOUT HexInsn *hi, HexPkt *pkt);
 void hexagon_disasm_0x0(const RzAsm *rz_asm, HexState *state, const ut32 hi_u32, RZ_INOUT HexInsn *hi, const ut32 addr, HexPkt *pkt);


### PR DESCRIPTION
Adds the missing `RZ_API` visibility prefix to the declaration of `hex_extend_op`.

The Windows build failed without it because of the mismatch between the header difference in `hexagon.h` and `hexagon_arch.c`.