### PR TITLE
Refresh timestamps only on code changes

### DIFF
--- a/LLVMImporter.py
+++ b/LLVMImporter.py
@@ -644,38 +644,43 @@ class LLVMImporter:
 
         with open(path, "w+") as dest:
             dest.writelines(code)
-            log("hexagon.c written to: {}".format(path), LogLevel.DEBUG)
+            log("hexagon.c written to: {}".format(path), LogLevel.INFO)
 
     # RIZIN SPECIFIC
-    @staticmethod
-    def build_asm_hexagon_c(
-        path: str = "rizin/librz/asm/p/asm_hexagon.c",
-    ) -> None:
-        with open(path, "w+") as f:
-            f.write(get_generation_warning_c_code())
+    def build_asm_hexagon_c(self, path: str = "./rizin/librz/asm/p/asm_hexagon.c") -> None:
+        code = get_generation_warning_c_code()
 
-            with open("handwritten/asm_hexagon_c/include.c") as include:
-                set_pos_after_license(include)
-                f.writelines(include.readlines())
-            with open("handwritten/asm_hexagon_c/initialization.c") as init:
-                set_pos_after_license(init)
-                f.writelines(init.readlines())
-        log("asm_hexagon.c written to {}".format(path), LogLevel.DEBUG)
+        with open("handwritten/asm_hexagon_c/include.c") as include:
+            set_pos_after_license(include)
+            code += "".join(include.readlines())
+        with open("handwritten/asm_hexagon_c/initialization.c") as init:
+            set_pos_after_license(init)
+            code += "".join(init.readlines())
+
+        if compare_src_to_old_src(code, path):
+            self.unchanged_files.append(path)
+            return
+        with open(path, "w+") as dest:
+            dest.writelines(code)
+            log("asm_hexagon.c written to {}".format(path), LogLevel.INFO)
 
     # RIZIN SPECIFIC
-    @staticmethod
-    def build_hexagon_arch_c(
-        path: str = "rizin/librz/asm/arch/hexagon/hexagon_arch.c",
-    ):
-        with open(path, "w+") as f:
-            f.write(get_generation_warning_c_code())
+    def build_hexagon_arch_c(self, path: str = "./rizin/librz/asm/arch/hexagon/hexagon_arch.c"):
+        code = get_generation_warning_c_code()
 
-            with open("handwritten/hexagon_arch_c/include.c") as include:
-                set_pos_after_license(include)
-                f.writelines(include.readlines())
-            with open("handwritten/hexagon_arch_c/functions.c") as functions:
-                set_pos_after_license(functions)
-                f.writelines(functions.readlines())
+        with open("handwritten/hexagon_arch_c/include.c") as include:
+            set_pos_after_license(include)
+            code += "".join(include.readlines())
+        with open("handwritten/hexagon_arch_c/functions.c") as functions:
+            set_pos_after_license(functions)
+            code += "".join(functions.readlines())
+
+        if compare_src_to_old_src(code, path):
+            self.unchanged_files.append(path)
+            return
+        with open(path, "w+") as dest:
+            dest.writelines(code)
+            log("asm_hexagon.c written to {}".format(path), LogLevel.INFO)
 
     # RIZIN SPECIFIC
     @staticmethod

--- a/LLVMImporter.py
+++ b/LLVMImporter.py
@@ -683,25 +683,27 @@ class LLVMImporter:
             log("asm_hexagon.c written to {}".format(path), LogLevel.INFO)
 
     # RIZIN SPECIFIC
-    @staticmethod
-    def build_hexagon_arch_h(
-        path: str = "rizin/librz/asm/arch/hexagon/hexagon_arch.h",
-    ):
-        with open(path, "w+") as f:
-            f.write(get_generation_warning_c_code())
+    def build_hexagon_arch_h(self, path: str = "./rizin/librz/asm/arch/hexagon/hexagon_arch.h"):
+        code = get_generation_warning_c_code()
+        code += get_include_guard("hexagon_arch.h")
 
-            f.write(get_include_guard("hexagon_arch.h"))
+        with open("handwritten/hexagon_arch_h/includes.h") as includes:
+            set_pos_after_license(includes)
+            code += "".join(includes.readlines())
+        with open("handwritten/hexagon_arch_h/typedefs.h") as typedefs:
+            set_pos_after_license(typedefs)
+            code += "".join(typedefs.readlines())
+        with open("handwritten/hexagon_arch_h/declarations.h") as declarations:
+            set_pos_after_license(declarations)
+            code += "".join(declarations.readlines())
+        code += "\n#endif\n"
 
-            with open("handwritten/hexagon_arch_h/includes.h") as includes:
-                set_pos_after_license(includes)
-                f.writelines(includes.readlines())
-            with open("handwritten/hexagon_arch_h/typedefs.h") as typedefs:
-                set_pos_after_license(typedefs)
-                f.writelines(typedefs.readlines())
-            with open("handwritten/hexagon_arch_h/declarations.h") as declarations:
-                set_pos_after_license(declarations)
-                f.writelines(declarations.readlines())
-            f.write("#endif\n")
+        if compare_src_to_old_src(code, path):
+            self.unchanged_files.append(path)
+            return
+        with open(path, "w+") as dest:
+            dest.writelines(code)
+            log("hexagon_arch.h written to {}".format(path), LogLevel.INFO)
 
     # RIZIN SPECIFIC
     @staticmethod

--- a/handwritten/analysis_hexagon_c/include.c
+++ b/handwritten/analysis_hexagon_c/include.c
@@ -9,4 +9,3 @@
 #include "hexagon.h"
 #include "hexagon_insn.h"
 #include "hexagon_arch.h"
-

--- a/handwritten/hexagon_arch_c/functions.c
+++ b/handwritten/hexagon_arch_c/functions.c
@@ -418,7 +418,6 @@ static void hex_set_pkt_info(const RzAsm *rz_asm, RZ_INOUT HexInsn *hi, const He
 	}
 }
 
-
 /**
  * \brief Returns the loop type of a packet. Though only if this packet is
  * 	the last packet in last packet in a hardware loop. Otherwise it returns

--- a/helperFunctions.py
+++ b/helperFunctions.py
@@ -272,6 +272,19 @@ def get_generation_timestamp(conf: dict) -> str:
     return commit
 
 
+def compare_src_to_old_src(new_src: str, comp_src_file: str) -> bool:
+    """ Compares each line of the new_src string and the src code in the file comp_src_file. """
+    with open(comp_src_file) as f:
+        for line in f:
+            if "Date of code generation" in line:
+                break
+        old_src = f.readlines()
+    for l_new, l_old in zip(new_src.split("\n"), old_src):
+        if l_new != l_old:
+            return False
+    return True
+
+
 def indent_code_block(code: str, indent_depth: int) -> str:
     ret = ""
     indent: str = PluginInfo.LINE_INDENT

--- a/helperFunctions.py
+++ b/helperFunctions.py
@@ -279,10 +279,11 @@ def compare_src_to_old_src(new_src: str, comp_src_file: str) -> bool:
             if "Date of code generation" in line:
                 break
         old_src = f.readlines()
-    for l_new, l_old in zip(new_src.split("\n"), old_src):
-        # Remove clang-format introduced blanks.
-        if re.sub(r"\s", "", l_new) != re.sub(r"\s", "", l_old):
-            return False
+    l_new = "".join(new_src)
+    l_old = "".join(old_src)
+    # Remove clang-format introduced blanks.
+    if re.sub(r"\s", "", l_new) != re.sub(r"\s", "", l_old):
+        return False
     return True
 
 

--- a/helperFunctions.py
+++ b/helperFunctions.py
@@ -280,7 +280,8 @@ def compare_src_to_old_src(new_src: str, comp_src_file: str) -> bool:
                 break
         old_src = f.readlines()
     for l_new, l_old in zip(new_src.split("\n"), old_src):
-        if l_new != l_old:
+        # Remove clang-format introduced blanks.
+        if re.sub(r"\s", "", l_new) != re.sub(r"\s", "", l_old):
             return False
     return True
 


### PR DESCRIPTION
Currently the timestamps in file headers are always updated on generation. Even if no actual code has been edited.

This PR changes that. It Compares the generated code against the code in the files and only writes, if it finds a differences.