### PR TITLE
Generate instruction templates as C structs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ rz_hexagon.egg-info/
 Hexagon.json
 .config
 .last_llvm_commit_info
+/venv/

--- a/DuplexInstruction.py
+++ b/DuplexInstruction.py
@@ -11,7 +11,7 @@ from Immediate import Immediate
 from ImplementationException import ImplementationException
 from InstructionEncoding import InstructionEncoding
 from InstructionTemplate import InstructionTemplate, LoopMembership
-from Operand import Operand, OperandType
+from Operand import Operand, OperandType, SparseMask
 from Register import Register
 from SubInstruction import SubInstruction, SubInstrNamespace
 from UnexpectedException import UnexpectedException
@@ -174,8 +174,7 @@ class DuplexInstruction(InstructionTemplate):
                     mask = self.encoding.operand_masks[op_name[:-2]]  # Ends with "in"
                 else:
                     mask = self.encoding.operand_masks[op_name]
-                operand.opcode_mask = mask
-                operand.add_code_for_opcode_parsing(Operand.make_sparse_mask(mask))
+                operand.opcode_mask = SparseMask(mask)
 
             # On the fly check whether the new values have been assigned correctly.
             if op_name + ".new" in self.llvm_syntax:

--- a/HardwareRegister.py
+++ b/HardwareRegister.py
@@ -73,23 +73,6 @@ class HardwareRegister(Register):
 
     # RIZIN SPECIFIC
     @staticmethod
-    def get_func_name_of_class(reg_class: str, is_n_reg: bool) -> str:
-        """
-        Generates the name of the function, which will return the register name for the given register number.
-        Args:
-            reg_class: The LLVM register class.
-            is_n_reg: True if the register is a Nt.new register, false otherwise.
-
-        Returns: Name of the function which resolves the register name for a given number.
-        """
-        if is_n_reg:
-            return "resolve_n_register"
-        reg_func = HardwareRegister.register_class_name_to_upper(reg_class).lower()
-        code = PluginInfo.GENERAL_ENUM_PREFIX.lower() + "get_" + reg_func
-        return code
-
-    # RIZIN SPECIFIC
-    @staticmethod
     def get_parse_code_reg_bits(reg_class: str, var: str) -> str:
         """Sub register bits are encoded in a space saving way in the instruction encoding.
         So we need to shift the bits around before we get the register ID. Here we generate the code for that.
@@ -156,13 +139,3 @@ class HardwareRegister(Register):
             return "sys"
         else:
             raise ImplementationException("Rizin has no register type for the register {}".format(self.llvm_type))
-
-    @staticmethod
-    def register_class_name_to_upper(s: str) -> str:
-        """Separates words by an '_' and sets them upper case: IntRegsLow8 -> INT_REGS_LOW8"""
-        matches = re.findall(r"[A-Z][a-z0-9]+", s)
-        for match in matches:
-            s = re.sub(match, match.upper() + "_", s)
-        if s[-1] == "_":
-            s = s[:-1]
-        return s

--- a/Instruction.py
+++ b/Instruction.py
@@ -9,7 +9,7 @@ import PluginInfo
 from Immediate import Immediate
 from ImplementationException import ImplementationException
 from InstructionTemplate import InstructionTemplate, LoopMembership
-from Operand import Operand, OperandType
+from Operand import Operand, OperandType, SparseMask
 from InstructionEncoding import InstructionEncoding
 from Register import Register
 from helperFunctions import normalize_llvm_syntax, list_to_int
@@ -169,8 +169,7 @@ class Instruction(InstructionTemplate):
                     mask = self.encoding.operand_masks[op_name[:-2]]  # Ends with "in"
                 else:
                     mask = self.encoding.operand_masks[op_name]
-                operand.opcode_mask = mask
-                operand.add_code_for_opcode_parsing(Operand.make_sparse_mask(mask))
+                operand.opcode_mask = SparseMask(mask)
 
             # On the fly check whether the new values have been assigned correctly.
             if op_name + ".new" in self.llvm_syntax:

--- a/InstructionTemplate.py
+++ b/InstructionTemplate.py
@@ -215,7 +215,7 @@ class InstructionTemplate:
 
             if op.type == OperandType.REGISTER:
                 op: Register
-                code += "{}hi->ops[{}].op.reg = {}".format(indent, op.syntax_index, op.code_opcode_parsing)
+                code += "{}hi->ops[{}].op.reg = {}".format(indent, op.syntax_index, op.c_opcode_parsing)
                 if op.is_out_operand:
                     code += "hi->ops[{}].attr |= HEX_OP_REG_OUT;\n".format(op.syntax_index)
                 if op.is_double:
@@ -240,7 +240,7 @@ class InstructionTemplate:
                     )
 
             elif op.type == OperandType.IMMEDIATE and not op.is_constant:
-                code += "{}hi->ops[{}].op.imm = {}".format(indent, op.syntax_index, op.code_opcode_parsing)
+                code += "{}hi->ops[{}].op.imm = {}".format(indent, op.syntax_index, op.c_opcode_parsing)
                 h = "#" if op.total_width != 32 else "##"
                 # If there is only one immediate operand in the instruction extend it anyways.
                 # LLVM marks some operands as not extendable, although they are.

--- a/InstructionTemplate.py
+++ b/InstructionTemplate.py
@@ -196,7 +196,7 @@ class InstructionTemplate:
         code += "hi->instruction = {};\n".format(self.plugin_name)
         code += "hi->opcode = hi_u32;\n"
         code += "hi->parse_bits = (({}) & 0x{:x}) >> 14;\n".format(var, self.encoding.parse_bits_mask)
-        code += self.get_predicate_init()
+        code += f"hi->pred = {self.get_predicate()};"
 
         if self.is_duplex:
             code += "{}hi->duplex = {};\n".format(indent, str(self.is_duplex).lower())
@@ -345,22 +345,18 @@ class InstructionTemplate:
         return code
 
     # RIZIN SPECIFIC
-    def get_predicate_init(self) -> str:
-        code = "hi->pred = "
+    def get_predicate(self) -> str:
         if not self.is_predicated:
-            code += "HEX_NOPRED;\n"
-            return code
-
-        if self.is_pred_false:
-            code += "| HEX_PRED_FALSE"
-        if self.is_pred_true:
-            code += "| HEX_PRED_TRUE"
-        if self.is_pred_new:
-            code += "| HEX_PRED_NEW"
-        if "= |" in code:
-            code = re.sub(r"= \|", "= ", code)
-        code += ";\n"
-        return code
+            pred = ["HEX_NOPRED"]
+        else:
+            pred = []
+            if self.is_pred_false:
+                pred.append("HEX_PRED_FALSE")
+            if self.is_pred_true:
+                pred.append("HEX_PRED_TRUE")
+            if self.is_pred_new:
+                pred.append("HEX_PRED_NEW")
+        return " | ".join(pred)
 
     # RIZIN SPECIFIC
     def get_rz_cond_type(self):

--- a/InstructionTemplate.py
+++ b/InstructionTemplate.py
@@ -223,7 +223,7 @@ class InstructionTemplate:
                 if op.is_quadruple:
                     code += "hi->ops[{}].attr |= HEX_OP_REG_QUADRUPLE;\n".format(op.syntax_index)
 
-                mnemonic = re.sub(op.explicit_syntax, "%s", mnemonic)
+                mnemonic = re.sub(op.explicit_syntax, "%s", mnemonic, count=1)
                 src = "hi->ops[{}].op.reg".format(op.syntax_index)
                 if op.is_n_reg:
                     sprint_src += ", {}({}({}, hi->addr, pkt), {})".format(

--- a/Operand.py
+++ b/Operand.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-only
 
+from __future__ import annotations
+
 from enum import Enum
 
 from bitarray import bitarray
@@ -10,6 +12,81 @@ import HexagonArchInfo
 import PluginInfo
 from ImplementationException import ImplementationException
 from helperFunctions import normalize_llvm_syntax
+
+
+class SparseMask:
+    """
+    Generates the C code which extracts the Z bits of each operand.
+
+    Bits of an operand are scattered over the encoded instruction.
+    Here we assemble them by using the mask of the field.
+
+    Simple example:
+    Let the input mask of an immediate be: 0b1111111110011111111111110
+    The bits of the actual immediate in the instruction encoding
+    need to be concatenated ignoring bit 15:14 and bit 0 (the zeros in the example mask).
+    So this function returns C-code which shifts the bits of the immediate segments and ORs them
+    to represent a valid value.
+
+    hi_u32 is the encoded instruction from which we want to concatenate bit 24:16 and bit 13:1
+    (bit 31:25 are ignored here)
+
+                 2           1
+             432109876 54 3210987654321 0     indices
+
+    Mask:    111111111|00|1111111111111|0
+    hi_u32:  100111101|00|1010000010011|0
+                 |                 |
+                 |                 |          bit[24:16] shifted three times to the right
+              +--+-----------------|------->  ((hi_u32 & 0x1ff0000) >> 3)
+          ____|____                |
+          1001111010000000000000   |                                   bit[13:1] shifted once to the right
+    OR             1010000010011 --+---------------------------------> ((hi_u32 & 0x3ffe) >> 1))
+          _______________________
+    imm = 1001111011010000010011
+
+    output:
+        imm = ((hi_u32 & 0x1ff0000) >> 3) | ((hi_u32 & 0x3ffe) >> 1))
+
+    Args:
+        mask: Mask of the immediate/register
+    """
+    def __init__(self, mask: bitarray):
+        self.full_mask = mask
+        switch = False
+        masks_count = 0  # How many parts the mask has
+        masks = {}
+        bshift = {}
+        for i in range(0, 32):
+            if mask[i]:
+                if not switch:
+                    switch = True
+                    masks_count += 1
+                    bshift[masks_count - 1] = i
+                if masks_count - 1 in masks:
+                    masks[masks_count - 1] += 1
+                else:
+                    masks[masks_count - 1] = 1
+            else:
+                switch = False
+
+        self.masks = [(masks[i], bshift[i]) for i in range(masks_count)]
+
+    @property
+    def c_expr(self):
+        """Returns: C code which does the bit masking + shifting."""
+        outstrings = []
+        off = 0
+        for (bits, shift) in self.masks:
+            outstrings.insert(0, "((({0:s}) & 0x{1:x}) >> {2:d})".format(
+                PluginInfo.HEX_INSTR_VAR_SYNTAX,
+                ((1 << bits) - 1) << shift,
+                shift - off))
+            off += bits
+        outstring = " | ".join(outstrings)
+        if "|" in outstring:
+            outstring = "({0:s})".format(outstring)
+        return outstring
 
 
 class OperandType(Enum):
@@ -34,9 +111,8 @@ class Operand:
         "is_in_operand",
         "is_out_operand",
         "is_in_out_operand",
-        "code_opcode_parsing",
         "type",
-        "opcode_mask",
+        "opcode_mask"
     ]
 
     def __init__(self, llvm_syntax: str, llvm_type: str, syntax_index: int):
@@ -45,89 +121,15 @@ class Operand:
         self.type: OperandType = self.get_operand_type(llvm_type)
         self.syntax_index = syntax_index
         self.explicit_syntax = normalize_llvm_syntax(self.llvm_syntax)
-        self.code_opcode_parsing = ""
-        self.opcode_mask: bitarray = bitarray()
+        self.opcode_mask: SparseMask = None
 
         self.is_in_operand = False
         self.is_out_operand = False
         self.is_in_out_operand = False
 
-    def add_code_for_opcode_parsing(self, parsing_code: str) -> None:
+    @property
+    def c_opcode_parsing(self) -> str | None:
         raise ImplementationException("You need to override this method.")
-
-    # RIZIN SPECIFIC
-    @staticmethod
-    def make_sparse_mask(mask: bitarray) -> str:
-        """
-        Generates the C code which extracts the Z bits of each operand.
-
-        Bits of an operand are scattered over the encoded instruction.
-        Here we assemble them by using the mask of the field.
-
-        Simple example:
-        Let the input mask of an immediate be: 0b1111111110011111111111110
-        The bits of the actual immediate in the instruction encoding
-        need to be concatenated ignoring bit 15:14 and bit 0 (the zeros in the example mask).
-        So this function returns C-code which shifts the bits of the immediate segments and ORs them
-        to represent a valid value.
-
-        hi_u32 is the encoded instruction from which we want to concatenate bit 24:16 and bit 13:1
-        (bit 31:25 are ignored here)
-
-                     2           1
-                 432109876 54 3210987654321 0     indices
-
-        Mask:    111111111|00|1111111111111|0
-        hi_u32:  100111101|00|1010000010011|0
-                     |                 |
-                     |                 |          bit[24:16] shifted three times to the right
-                  +--+-----------------|------->  ((hi_u32 & 0x1ff0000) >> 3)
-              ____|____                |
-              1001111010000000000000   |                                   bit[13:1] shifted once to the right
-        OR             1010000010011 --+---------------------------------> ((hi_u32 & 0x3ffe) >> 1))
-              _______________________
-        imm = 1001111011010000010011
-
-        output:
-            imm = ((hi_u32 & 0x1ff0000) >> 3) | ((hi_u32 & 0x3ffe) >> 1))
-
-        Args:
-            mask: Mask of the immediate/register
-
-        Returns: Returns the C code which does the bit masking + shifting.
-
-        """
-
-        switch = False
-        ncount = 0  # counts how many bits were *not* set.
-        masks_count = 0  # How many parts the mask has
-        masks = {}
-        bshift = {}
-        for i in range(0, 32):
-            if mask[i]:
-                if not switch:
-                    switch = True
-                    masks_count += 1
-                    bshift[masks_count] = ncount
-                if masks_count in masks:
-                    masks[masks_count] |= 1 << i
-                else:
-                    masks[masks_count] = 1 << i
-            else:
-                switch = False
-                ncount += 1
-
-        outstrings = []
-        for i in range(masks_count, 0, -1):
-            outstrings += [
-                "((({0:s}) & 0x{1:x}) >> {2:d})".format(PluginInfo.HEX_INSTR_VAR_SYNTAX, masks[i], bshift[i])
-            ]
-        outstring = " | ".join(outstrings)
-        if "|" in outstring:
-            outstring = "({0:s})".format(outstring)
-
-        # log("Generated mask C code: {}".format(outstring), LogLevel.VERBOSE)
-        return outstring
 
     @staticmethod
     def get_operand_type(operand_type: str) -> OperandType:

--- a/README.md
+++ b/README.md
@@ -126,6 +126,6 @@ So here are some good to know points for porting:
 # Contributors
 
 * Rot127
-
 * Anton Kochkov
+* Florian Märkl
 

--- a/Register.py
+++ b/Register.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-only
 
+from __future__ import annotations
+
 import re
 
 from ImplementationException import ImplementationException
@@ -152,8 +154,8 @@ class Register(Operand):
             raise ImplementationException("Unhandled register type: {}".format(self.llvm_reg_class))
 
     # RIZIN SPECIFIC
-    def add_code_for_opcode_parsing(self, parsing_code: str) -> None:
-        """Overrides method of parent class. Here we add code which does specific parsing of the operand value on
-        disassembly.
+    @property
+    def c_opcode_parsing(self) -> str | None:
+        """Code which does specific parsing of the operand value on disassembly.
         """
-        self.code_opcode_parsing = parsing_code + "; // {}\n".format(self.llvm_syntax)
+        return "{}; // {}\n".format(self.opcode_mask.c_expr, self.llvm_syntax)

--- a/Tests/testEncoding.py
+++ b/Tests/testEncoding.py
@@ -9,7 +9,7 @@ import PluginInfo
 from DuplexInstruction import DuplexInstruction
 from LLVMImporter import LLVMImporter
 from InstructionEncoding import InstructionEncoding
-from Operand import Operand
+from Operand import Operand, SparseMask
 from SubInstruction import SubInstruction
 
 
@@ -96,14 +96,14 @@ class TestInstructionEncoding(unittest.TestCase):
 
         self.assertEqual(
             "((({}) & 0x1fe0) >> 5)".format(hex_insn),
-            Operand.make_sparse_mask(InstructionEncoding(self.json["A2_combineii"]["Inst"]).operand_masks["Ii"]),
+            SparseMask(InstructionEncoding(self.json["A2_combineii"]["Inst"]).operand_masks["Ii"]).c_expr,
         )
         self.assertEqual(
             "(((({}) & 0x7f0000) >> 15) | ((({}) & 0x2000) >> 13))".format(hex_insn, hex_insn),
-            Operand.make_sparse_mask(InstructionEncoding(self.json["A2_combineii"]["Inst"]).operand_masks["II"]),
+            SparseMask(InstructionEncoding(self.json["A2_combineii"]["Inst"]).operand_masks["II"]).c_expr,
         )
 
         self.assertEqual(
             "(((({}) & 0xfff0000) >> 2) | ((({}) & 0x3fff) >> 0))".format(hex_insn, hex_insn),
-            Operand.make_sparse_mask(InstructionEncoding(self.json["A4_ext"]["Inst"]).operand_masks["Ii"]),
+            SparseMask(InstructionEncoding(self.json["A4_ext"]["Inst"]).operand_masks["Ii"]).c_expr,
         )

--- a/Tests/testEncoding.py
+++ b/Tests/testEncoding.py
@@ -9,7 +9,7 @@ import PluginInfo
 from DuplexInstruction import DuplexInstruction
 from LLVMImporter import LLVMImporter
 from InstructionEncoding import InstructionEncoding
-from Operand import Operand, SparseMask
+from Operand import SparseMask
 from SubInstruction import SubInstruction
 
 
@@ -92,18 +92,16 @@ class TestInstructionEncoding(unittest.TestCase):
 
     # RIZIN SPECIFIC
     def test_shifting_c_code(self) -> None:
-        hex_insn = PluginInfo.HEX_INSTR_VAR_SYNTAX
-
         self.assertEqual(
-            "((({}) & 0x1fe0) >> 5)".format(hex_insn),
-            SparseMask(InstructionEncoding(self.json["A2_combineii"]["Inst"]).operand_masks["Ii"]).c_expr,
+            "{ 0x8, 5 }",
+            SparseMask(InstructionEncoding(self.json["A2_combineii"]["Inst"]).operand_masks["Ii"]).c_template,
         )
         self.assertEqual(
-            "(((({}) & 0x7f0000) >> 15) | ((({}) & 0x2000) >> 13))".format(hex_insn, hex_insn),
-            SparseMask(InstructionEncoding(self.json["A2_combineii"]["Inst"]).operand_masks["II"]).c_expr,
+            "{ 0x1, 13 }, { 0x7, 16 }",
+            SparseMask(InstructionEncoding(self.json["A2_combineii"]["Inst"]).operand_masks["II"]).c_template,
         )
 
         self.assertEqual(
-            "(((({}) & 0xfff0000) >> 2) | ((({}) & 0x3fff) >> 0))".format(hex_insn, hex_insn),
-            SparseMask(InstructionEncoding(self.json["A4_ext"]["Inst"]).operand_masks["Ii"]).c_expr,
+            "{ 0xe, 0 }, { 0xc, 16 }",
+            SparseMask(InstructionEncoding(self.json["A4_ext"]["Inst"]).operand_masks["Ii"]).c_template,
         )

--- a/handwritten/analysis-tests/hexagon
+++ b/handwritten/analysis-tests/hexagon
@@ -215,7 +215,7 @@ EXPECT=<<EOF
 |   P2 = cmp.eq(R1,##0x1)
 \   P3 = cmp.eq(R1,##0x2)
 /   R3 = add(R3,##0x4)
-\   R4 = add(R4in,##0x4) ; R5 = add(R5,#1)     < endloop0
+\   R4 = add(R4,##0x4) ; R5 = add(R5,#1)     < endloop0
 EOF
 RUN
 

--- a/handwritten/asm-tests/hexagon
+++ b/handwritten/asm-tests/hexagon
@@ -17,6 +17,7 @@ d "?   R1:0 = memd(R29+#0x40) ; if (P0) dealloc_return" 441f403e 0x0
 d "?   R7:6 = memd(R29+#0x40) ; if (!P0) dealloc_return" 451f433e 0x0
 d "?   R23:22 = combine(#0,#0x2) ; R17:16 = memd(R29+#0x40)" 443e475c 0x0
 d "?   if (!P0.new) R23 = #0 ; jumpr R31" c03f5f5a 0x0
+d "?   R4 = add(R4,##0x4) ; R5 = add(R5,#1)" 55314420
 
 d "?   G9:8 = R9:8" 08c00863 0x0
 d "?   GELR = LR" 00c01f62 0x0

--- a/handwritten/hexagon_disas_c/functions.c
+++ b/handwritten/hexagon_disas_c/functions.c
@@ -6,3 +6,255 @@ static inline bool is_last_instr(const ut8 parse_bits) {
 	return ((parse_bits == 0x3) || (parse_bits == 0x0));
 }
 
+/**
+ * \param masks array of exactly HEX_OP_MASKS_MAX items, ordered ascending by shift,
+ *		optionally terminated earlier by an entry with bits = 0
+ */
+static ut32 hex_op_masks_extract(const HexOpMask *masks, ut32 val, RZ_OUT ut32 *bits_total) {
+	ut8 off = 0;
+	ut32 r = 0;
+	for (size_t i = 0; i < HEX_OP_MASKS_MAX; i++) {
+		const HexOpMask *m = &masks[i];
+		if (!m->bits) {
+			break;
+		}
+		r |= ((val >> m->shift) & rz_num_bitmask(m->bits)) << off;
+		off += m->bits;
+	}
+	if (bits_total) {
+		*bits_total = off;
+	}
+	return r;
+}
+
+/**
+ * \return the index of the immediate operand used as the jump target or -1 if there is none.
+ */
+static int get_jmp_target_imm_op_index(const HexInsnTemplate *tpl) {
+	if (!(tpl->flags & HEX_INSN_TEMPLATE_FLAG_HAS_JMP_TGT)) {
+		return -1;
+	}
+	bool has_imm = false;
+	size_t i;
+	for (i = 0; i < HEX_MAX_OPERANDS; i++) {
+		const HexOpTemplate *op = &tpl->ops[i];
+		HexOpTemplateType type = op->info & HEX_OP_TEMPLATE_TYPE_MASK;
+		if (type == HEX_OP_TEMPLATE_TYPE_NONE) {
+			break;
+		}
+		if (type == HEX_OP_TEMPLATE_TYPE_IMM) {
+			has_imm = true;
+			if (op->info & HEX_OP_TEMPLATE_FLAG_IMM_PC_RELATIVE) {
+				return i;
+			}
+		}
+	}
+	return has_imm && i == 1 ? 0 : -1;
+}
+
+static void hex_disasm_with_templates(const HexInsnTemplate *tpl, HexState *state, ut32 hi_u32, RZ_INOUT HexInsn *hi, ut64 addr, HexPkt *pkt) {
+	bool print_reg_alias = rz_config_get_b(state->cfg, "plugins.hexagon.reg.alias");
+	bool show_hash = rz_config_get_b(state->cfg, "plugins.hexagon.imm.hash");
+	bool sign_nums = rz_config_get_b(state->cfg, "plugins.hexagon.imm.sign");
+	char signed_imm[HEX_MAX_OPERANDS][32];
+	// Find the right template
+	for (; tpl->id; tpl++) {
+		if ((hi_u32 & tpl->encoding.mask) == tpl->encoding.op) {
+			break;
+		}
+	}
+	if (!tpl->id) {
+		// unknown/invalid
+		return;
+	}
+	hi->instruction = tpl->id;
+	hi->opcode = hi_u32;
+	hi->parse_bits = (hi_u32 & HEX_PARSE_BITS_MASK) >> 14;
+	hi->pred = tpl->pred;
+
+	// textual disasm is built by copying tpl->syntax while inserting the ops at the right positions
+	RzStrBuf sb;
+	rz_strbuf_init(&sb);
+	size_t syntax_cur = 0;
+	size_t syntax_len = strlen(tpl->syntax);
+
+	hi->op_count = 0;
+	for (size_t i = 0; i < HEX_MAX_OPERANDS; i++) {
+		const HexOpTemplate *op = &tpl->ops[i];
+		HexOpTemplateType type = op->info & HEX_OP_TEMPLATE_TYPE_MASK;
+		if (type == HEX_OP_TEMPLATE_TYPE_NONE) {
+			break;
+		}
+
+		if (op->syntax > syntax_cur && op->syntax <= syntax_len) {
+			rz_strbuf_append_n(&sb, tpl->syntax + syntax_cur, op->syntax - syntax_cur);
+			syntax_cur = op->syntax;
+		}
+
+		hi->op_count++;
+		hi->ops[i].attr = 0;
+		switch (type) {
+		case HEX_OP_TEMPLATE_TYPE_IMM: {
+			hi->ops[i].type = HEX_OP_TYPE_IMM;
+			ut32 bits_total;
+			hi->ops[i].op.imm = hex_op_masks_extract(op->masks, hi_u32, &bits_total) << op->imm_scale;
+			hi->ops[i].shift = op->imm_scale;
+			if (op->imm_scale) {
+				hi->ops[i].attr |= HEX_OP_IMM_SCALED;
+			}
+			if (op->info & HEX_OP_TEMPLATE_FLAG_IMM_SIGNED) {
+				ut32 shift = bits_total + op->imm_scale - 1;
+				rz_warn_if_fail(shift < 64);
+				if (hi->ops[i].op.imm & (1ull << shift)) {
+					hi->ops[i].op.imm |= UT64_MAX << shift;
+				}
+			}
+			if (op->info & HEX_OP_TEMPLATE_FLAG_IMM_EXTENDABLE) {
+				hex_extend_op(state, &hi->ops[i], false, addr);
+			}
+			// textual disasm
+			const char *h = show_hash ? ((op->info & HEX_OP_TEMPLATE_FLAG_IMM_DOUBLE_HASH) ? "##" : "#") : "";
+			if (op->info & HEX_OP_TEMPLATE_FLAG_IMM_PC_RELATIVE) {
+				rz_strbuf_appendf(&sb, "0x%" PFMT32x, pkt->pkt_addr + (st32)hi->ops[i].op.imm);
+			} else if (op->info & HEX_OP_TEMPLATE_FLAG_IMM_SIGNED) {
+				if (sign_nums && ((st32)hi->ops[i].op.imm) < 0) {
+					char tmp[28] = {0};
+					rz_hex_ut2st_str(hi->ops[i].op.imm, tmp, 28);
+					snprintf(signed_imm[i], sizeof(signed_imm[i]), "%s%s", h, tmp);
+				} else {
+					snprintf(signed_imm[i], sizeof(signed_imm[i]), "%s0x%" PFMT32x, h, (st32)hi->ops[i].op.imm);
+				}
+				rz_strbuf_append(&sb, signed_imm[i]);
+			} else {
+				rz_strbuf_appendf(&sb, "%s0x%" PFMT32x, h, (ut32)hi->ops[i].op.imm);
+			}
+			break;
+		}
+		case HEX_OP_TEMPLATE_TYPE_IMM_CONST:
+			hi->ops[i].type = HEX_OP_TYPE_IMM;
+			hi->ops[i].op.imm = -1;
+			// textual disasm
+			rz_strbuf_append(&sb, "-1");
+			break;
+		case HEX_OP_TEMPLATE_TYPE_REG:
+			hi->ops[i].type = HEX_OP_TYPE_REG;
+			hi->ops[i].op.reg = hex_op_masks_extract(op->masks, hi_u32, NULL);
+			if (op->info & HEX_OP_TEMPLATE_FLAG_REG_OUT) {
+				hi->ops[i].attr |= HEX_OP_REG_OUT;
+			}
+			if (op->info & HEX_OP_TEMPLATE_FLAG_REG_PAIR) {
+				hi->ops[i].attr |= HEX_OP_REG_PAIR;
+			}
+			if (op->info & HEX_OP_TEMPLATE_FLAG_REG_QUADRUPLE) {
+				hi->ops[i].attr |= HEX_OP_REG_QUADRUPLE;
+			}
+			// textual disasm
+			int regidx = hi->ops[i].op.reg;
+			if (op->info & HEX_OP_TEMPLATE_FLAG_REG_N_REG) {
+				regidx = resolve_n_register(hi->ops[i].op.reg, hi->addr, pkt);
+			}
+			rz_strbuf_append(&sb, hex_get_reg_in_class(op->reg_cls, regidx, print_reg_alias));
+			break;
+		default:
+			rz_warn_if_reached();
+			break;
+		}
+	}
+
+	// Textual disassembly
+	if (syntax_len > syntax_cur) {
+		rz_strbuf_append_n(&sb, tpl->syntax + syntax_cur, syntax_len - syntax_cur);
+	}
+	strncpy(hi->mnem_infix, rz_strbuf_get(&sb), sizeof(hi->mnem_infix) - 1);
+	snprintf(hi->mnem, sizeof(hi->mnem), "%s%s%s", hi->pkt_info.mnem_prefix, hi->mnem_infix, hi->pkt_info.mnem_postfix);
+
+	// RzAnalysisOp contents
+	hi->ana_op.addr = hi->addr;
+	hi->ana_op.id = hi->instruction;
+	hi->ana_op.size = 4;
+	hi->ana_op.cond = tpl->cond;
+	hi->ana_op.type = hi->ana_op.prefix == RZ_ANALYSIS_OP_PREFIX_HWLOOP_END ? RZ_ANALYSIS_OP_TYPE_CJMP : tpl->type;
+	int jmp_target_imm_op_index = get_jmp_target_imm_op_index(tpl);
+	if (jmp_target_imm_op_index >= 0) {
+		if (!(tpl->flags & HEX_INSN_TEMPLATE_FLAG_CALL) && !(tpl->flags & HEX_INSN_TEMPLATE_FLAG_PREDICATED)) {
+			pkt->is_eob = true;
+		}
+		hi->ana_op.jump = pkt->pkt_addr + (st32)hi->ops[jmp_target_imm_op_index].op.imm;
+		if (tpl->flags & HEX_INSN_TEMPLATE_FLAG_PREDICATED) {
+			hi->ana_op.fail = hi->ana_op.addr + 4;
+		}
+		if (tpl->flags & HEX_INSN_TEMPLATE_FLAG_LOOP_BEGIN) {
+			if (tpl->flags & HEX_INSN_TEMPLATE_FLAG_LOOP_0) {
+				pkt->hw_loop0_addr = hi->ana_op.jump;
+			} else if (tpl->flags & HEX_INSN_TEMPLATE_FLAG_LOOP_1) {
+				pkt->hw_loop1_addr = hi->ana_op.jump;
+			}
+		}
+	}
+	for (size_t i = 0; i < RZ_MIN(hi->op_count, RZ_ARRAY_SIZE(hi->ana_op.analysis_vals)); i++) {
+		const HexOpTemplate *op = &tpl->ops[i];
+		HexOpTemplateType type = op->info & HEX_OP_TEMPLATE_TYPE_MASK;
+		if (jmp_target_imm_op_index >= 0 && type == HEX_OP_TEMPLATE_TYPE_IMM) {
+			hi->ana_op.val = hi->ana_op.jump;
+			hi->ana_op.analysis_vals[i].imm = hi->ana_op.jump;
+		} else if (tpl->id == HEX_INS_J2_JUMPR) {
+			// jumpr Rs is sometimes used as jumpr R31.
+			// Block analysis needs to check it to recognize if this jump is a return.
+			hi->ana_op.analysis_vals[0].plugin_specific = hi->ops[0].op.reg;
+		} else if (type == HEX_OP_TEMPLATE_TYPE_IMM) {
+			hi->ana_op.analysis_vals[i].imm = hi->ops[i].op.imm;
+		}
+	}
+
+	if (tpl->id == HEX_INS_A4_EXT) {
+		hex_extend_op(state, &(hi->ops[0]), true, addr);
+	}
+}
+
+int hexagon_disasm_instruction(HexState *state, const ut32 hi_u32, RZ_INOUT HexInsn *hi, HexPkt *pkt) {
+	ut32 addr = hi->addr;
+	if (hi->pkt_info.last_insn) {
+		switch (hex_get_loop_flag(pkt)) {
+		default: break;
+		case HEX_LOOP_01:
+			hi->ana_op.prefix = RZ_ANALYSIS_OP_PREFIX_HWLOOP_END;
+			hi->ana_op.fail = pkt->hw_loop0_addr;
+			hi->ana_op.jump = pkt->hw_loop1_addr;
+			hi->ana_op.val = hi->ana_op.jump;
+			break;
+		case HEX_LOOP_0:
+			hi->ana_op.prefix = RZ_ANALYSIS_OP_PREFIX_HWLOOP_END;
+			hi->ana_op.jump = pkt->hw_loop0_addr;
+			hi->ana_op.val = hi->ana_op.jump;
+			break;
+		case HEX_LOOP_1:
+			hi->ana_op.prefix = RZ_ANALYSIS_OP_PREFIX_HWLOOP_END;
+			hi->ana_op.jump = pkt->hw_loop1_addr;
+			hi->ana_op.val = hi->ana_op.jump;
+			break;
+		}
+	}
+	if (hi_u32 != 0x00000000) {
+		if (((hi_u32 >> 14) & 0x3) == 0) {
+			// DUPLEXES
+			ut32 cat = (((hi_u32 >> 29) & 0xF) << 1) | ((hi_u32 >> 13) & 1);
+			if (cat < 0xf) {
+				hex_disasm_with_templates(templates_duplex[cat], state, hi_u32, hi, addr, pkt);
+				hi->duplex = true;
+			}
+		} else {
+			ut32 cat = (hi_u32 >> 28) & 0xF;
+			hex_disasm_with_templates(templates_normal[cat], state, hi_u32, hi, addr, pkt);
+		}
+	}
+	if (pkt->is_eob && is_last_instr(hi->parse_bits)) {
+		hi->ana_op.eob = true;
+	}
+	if (hi->instruction == HEX_INS_INVALID_DECODE) {
+		hi->parse_bits = ((hi_u32)&0xc000) >> 14;
+		hi->ana_op.type = RZ_ANALYSIS_OP_TYPE_ILL;
+		sprintf(hi->mnem_infix, "invalid");
+		sprintf(hi->mnem, "%s%s%s", hi->pkt_info.mnem_prefix, hi->mnem_infix, hi->pkt_info.mnem_postfix);
+	}
+	return 4;
+}

--- a/handwritten/hexagon_disas_c/types.c
+++ b/handwritten/hexagon_disas_c/types.c
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2022 Florian Märkl <info@florianmaerkl.de>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#define HEX_OP_MASKS_MAX 4
+
+typedef enum {
+	HEX_OP_TEMPLATE_TYPE_NONE = 0,
+	HEX_OP_TEMPLATE_TYPE_IMM = 1,
+	HEX_OP_TEMPLATE_TYPE_IMM_CONST = 2,
+	HEX_OP_TEMPLATE_TYPE_REG = 3,
+	HEX_OP_TEMPLATE_TYPE_MASK = 3
+} HexOpTemplateType;
+
+typedef enum {
+	// 1 << 0 and 1 << 1 reserved by HexOpTemplateType
+	// for HEX_OP_TEMPLATE_TYPE_REG:
+	HEX_OP_TEMPLATE_FLAG_REG_OUT = 1 << 2,
+	HEX_OP_TEMPLATE_FLAG_REG_PAIR = 1 << 3,
+	HEX_OP_TEMPLATE_FLAG_REG_QUADRUPLE = 1 << 4,
+	HEX_OP_TEMPLATE_FLAG_REG_N_REG = 1 << 5,
+	// for HEX_OP_TEMPLATE_TYPE_IMM:
+	HEX_OP_TEMPLATE_FLAG_IMM_SIGNED = 1 << 2,
+	HEX_OP_TEMPLATE_FLAG_IMM_EXTENDABLE = 1 << 3,
+	HEX_OP_TEMPLATE_FLAG_IMM_PC_RELATIVE = 1 << 4,
+	HEX_OP_TEMPLATE_FLAG_IMM_DOUBLE_HASH = 1 << 5
+} HexOpTemplateFlag;
+
+// Note:
+// The structs below are using ut8 instead of direct enum types
+// where possible to optimize for size. Members are also ordered
+// deliberately to make them well packed.
+// Keep this in mind when changing anything here!
+
+typedef struct {
+	ut8 bits; // number of bits this part has
+	ut8 shift; // index of the first bit in the instruction where this part starts
+} HexOpMask;
+
+typedef struct {
+	ut8 info; // HexOpTemplateType | HexOpTemplateFlag
+	ut8 syntax; // offset into HexInsnTemplate.syntax where to insert this op
+	HexOpMask masks[HEX_OP_MASKS_MAX];
+	union {
+		ut8 imm_scale;
+		ut8 reg_cls; // HexRegClass
+	};
+} HexOpTemplate;
+
+typedef enum {
+	HEX_INSN_TEMPLATE_FLAG_CALL = 1 << 0,
+	HEX_INSN_TEMPLATE_FLAG_PREDICATED = 1 << 1,
+	HEX_INSN_TEMPLATE_FLAG_HAS_JMP_TGT = 1 << 2,
+	HEX_INSN_TEMPLATE_FLAG_LOOP_BEGIN = 1 << 3,
+	HEX_INSN_TEMPLATE_FLAG_LOOP_0 = 1 << 4,
+	HEX_INSN_TEMPLATE_FLAG_LOOP_1 = 1 << 5
+} HexInsnTemplateFlag;
+
+typedef struct {
+	struct {
+		ut32 mask;
+		ut32 op;
+	} encoding;
+	enum HEX_INS id;
+	HexOpTemplate ops[HEX_MAX_OPERANDS];
+	ut8 pred; // HexPred
+	ut8 cond; // RzTypeCond
+	ut8 flags; // HexInsnTemplateFlag
+	const char *syntax;
+	_RzAnalysisOpType type;
+} HexInsnTemplate;

--- a/handwritten/hexagon_h/typedefs.h
+++ b/handwritten/hexagon_h/typedefs.h
@@ -83,7 +83,7 @@ typedef struct {
 	int shift; // Optional shift left is it true?
 	HexPktInfo pkt_info; // Packet related information. First/last instr., prefix and postfix for mnemonic etc.
 	ut8 op_count;
-	HexOp ops[6];
+	HexOp ops[HEX_MAX_OPERANDS];
 	char mnem_infix[128]; // The mnemonic without the pre- and postfix.
 	char mnem[192]; // Instruction mnemonic
 	ut32 addr; // Memory address the instruction is located.

--- a/rizin/librz/asm/arch/hexagon/hexagon.c
+++ b/rizin/librz/asm/arch/hexagon/hexagon.c
@@ -3,7 +3,7 @@
 
 // LLVM commit: 96e220e6886868d6663d966ecc396befffc355e7
 // LLVM commit date: 2022-01-05 11:01:52 +0000 (ISO 8601 format)
-// Date of code generation: 2022-04-02 10:52:25-04:00
+// Date of code generation: 2022-04-11 18:58:34+02:00
 //========================================
 // The following code is generated.
 // Do not edit. Repository of code generator:
@@ -824,6 +824,46 @@ char *hex_get_sys_regs64(int opcode_reg, bool get_alias) {
 		return "S77:76";
 	case HEX_REG_SYS_REGS64_S79_78:
 		return "S79:78";
+	}
+}
+char *hex_get_reg_in_class(HexRegClass cls, int opcode_reg, bool get_alias) {
+	switch (cls) {
+	case HEX_REG_CLASS_CTR_REGS:
+		return hex_get_ctr_regs(opcode_reg, get_alias);
+	case HEX_REG_CLASS_CTR_REGS64:
+		return hex_get_ctr_regs64(opcode_reg, get_alias);
+	case HEX_REG_CLASS_DOUBLE_REGS:
+		return hex_get_double_regs(opcode_reg, get_alias);
+	case HEX_REG_CLASS_GENERAL_DOUBLE_LOW8_REGS:
+		return hex_get_general_double_low8_regs(opcode_reg, get_alias);
+	case HEX_REG_CLASS_GENERAL_SUB_REGS:
+		return hex_get_general_sub_regs(opcode_reg, get_alias);
+	case HEX_REG_CLASS_GUEST_REGS:
+		return hex_get_guest_regs(opcode_reg, get_alias);
+	case HEX_REG_CLASS_GUEST_REGS64:
+		return hex_get_guest_regs64(opcode_reg, get_alias);
+	case HEX_REG_CLASS_HVX_QR:
+		return hex_get_hvx_qr(opcode_reg, get_alias);
+	case HEX_REG_CLASS_HVX_VQR:
+		return hex_get_hvx_vqr(opcode_reg, get_alias);
+	case HEX_REG_CLASS_HVX_VR:
+		return hex_get_hvx_vr(opcode_reg, get_alias);
+	case HEX_REG_CLASS_HVX_WR:
+		return hex_get_hvx_wr(opcode_reg, get_alias);
+	case HEX_REG_CLASS_INT_REGS:
+		return hex_get_int_regs(opcode_reg, get_alias);
+	case HEX_REG_CLASS_INT_REGS_LOW8:
+		return hex_get_int_regs_low8(opcode_reg, get_alias);
+	case HEX_REG_CLASS_MOD_REGS:
+		return hex_get_mod_regs(opcode_reg, get_alias);
+	case HEX_REG_CLASS_PRED_REGS:
+		return hex_get_pred_regs(opcode_reg, get_alias);
+	case HEX_REG_CLASS_SYS_REGS:
+		return hex_get_sys_regs(opcode_reg, get_alias);
+	case HEX_REG_CLASS_SYS_REGS64:
+		return hex_get_sys_regs64(opcode_reg, get_alias);
+	default:
+		return NULL;
 	}
 }
 

--- a/rizin/librz/asm/arch/hexagon/hexagon.h
+++ b/rizin/librz/asm/arch/hexagon/hexagon.h
@@ -3,7 +3,7 @@
 
 // LLVM commit: 96e220e6886868d6663d966ecc396befffc355e7
 // LLVM commit date: 2022-01-05 11:01:52 +0000 (ISO 8601 format)
-// Date of code generation: 2022-04-02 10:48:34-04:00
+// Date of code generation: 2022-04-17 16:07:17+02:00
 //========================================
 // The following code is generated.
 // Do not edit. Repository of code generator:
@@ -16,6 +16,9 @@
 #include <rz_config.h>
 #include <rz_list.h>
 #include <rz_types.h>
+
+#define HEX_MAX_OPERANDS    6
+#define HEX_PARSE_BITS_MASK 0xc000
 
 #define MAX_CONST_EXT      512
 #define HEXAGON_STATE_PKTS 8
@@ -99,7 +102,7 @@ typedef struct {
 	int shift; // Optional shift left is it true?
 	HexPktInfo pkt_info; // Packet related information. First/last instr., prefix and postfix for mnemonic etc.
 	ut8 op_count;
-	HexOp ops[6];
+	HexOp ops[HEX_MAX_OPERANDS];
 	char mnem_infix[128]; // The mnemonic without the pre- and postfix.
 	char mnem[192]; // Instruction mnemonic
 	ut32 addr; // Memory address the instruction is located.
@@ -133,6 +136,27 @@ typedef struct {
 	RzAsm rz_asm; // Copy of RzAsm struct. Holds certain flags of interesed for disassembly formatting.
 	RzConfig *cfg;
 } HexState;
+
+typedef enum {
+	HEX_REG_CLASS_CTR_REGS,
+	HEX_REG_CLASS_CTR_REGS64,
+	HEX_REG_CLASS_DOUBLE_REGS,
+	HEX_REG_CLASS_GENERAL_DOUBLE_LOW8_REGS,
+	HEX_REG_CLASS_GENERAL_SUB_REGS,
+	HEX_REG_CLASS_GUEST_REGS,
+	HEX_REG_CLASS_GUEST_REGS64,
+	HEX_REG_CLASS_HVX_QR,
+	HEX_REG_CLASS_HVX_VQR,
+	HEX_REG_CLASS_HVX_VR,
+	HEX_REG_CLASS_HVX_WR,
+	HEX_REG_CLASS_INT_REGS,
+	HEX_REG_CLASS_INT_REGS_LOW8,
+	HEX_REG_CLASS_MOD_REGS,
+	HEX_REG_CLASS_PRED_REGS,
+	HEX_REG_CLASS_SYS_REGS,
+	HEX_REG_CLASS_SYS_REGS64
+} HexRegClass;
+
 typedef enum {
 	HEX_REG_CTR_REGS_C0 = 0, // sa0
 	HEX_REG_CTR_REGS_C1 = 1, // lc0
@@ -555,6 +579,7 @@ char *hex_get_mod_regs(int opcode_reg, bool get_alias);
 char *hex_get_pred_regs(int opcode_reg, bool get_alias);
 char *hex_get_sys_regs(int opcode_reg, bool get_alias);
 char *hex_get_sys_regs64(int opcode_reg, bool get_alias);
+char *hex_get_reg_in_class(HexRegClass cls, int opcode_reg, bool get_alias);
 
 RZ_API RZ_BORROW RzConfig *hexagon_get_config();
 RZ_API void hex_extend_op(HexState *state, RZ_INOUT HexOp *op, const bool set_new_extender, const ut32 addr);

--- a/rizin/test/db/analysis/hexagon
+++ b/rizin/test/db/analysis/hexagon
@@ -215,7 +215,7 @@ EXPECT=<<EOF
 |   P2 = cmp.eq(R1,##0x1)
 \   P3 = cmp.eq(R1,##0x2)
 /   R3 = add(R3,##0x4)
-\   R4 = add(R4in,##0x4) ; R5 = add(R5,#1)     < endloop0
+\   R4 = add(R4,##0x4) ; R5 = add(R5,#1)     < endloop0
 EOF
 RUN
 

--- a/rizin/test/db/asm/hexagon
+++ b/rizin/test/db/asm/hexagon
@@ -17,6 +17,7 @@ d "?   R1:0 = memd(R29+#0x40) ; if (P0) dealloc_return" 441f403e 0x0
 d "?   R7:6 = memd(R29+#0x40) ; if (!P0) dealloc_return" 451f433e 0x0
 d "?   R23:22 = combine(#0,#0x2) ; R17:16 = memd(R29+#0x40)" 443e475c 0x0
 d "?   if (!P0.new) R23 = #0 ; jumpr R31" c03f5f5a 0x0
+d "?   R4 = add(R4,##0x4) ; R5 = add(R5,#1)" 55314420
 
 d "?   G9:8 = R9:8" 08c00863 0x0
 d "?   GELR = LR" 00c01f62 0x0


### PR DESCRIPTION
# DO NOT SQUASH

Any instruction-specific info is now generated as constant C structures, rather than different executable code for each instruction. To achieve this, a lot of logic has been moved from the generator to the C code. The result is a drastic improvent wrt. compile times and code size, in both source and binary form.

Changes, like refactors, that would affect the old codegen too have been extracted into individual commits, so only the last commit in this pr is the "real" change and the previous are preparation. That is so any potential breakage in those changes can be tracked down much more easily.

Some comparison of why this change is beneficial for the compilation of `hexagon_disasm.c`:
| | before | after |
|-|-|-|
| compile time `-O0 -g` | 2.4s | 0.3s |
| compile time `-O3` | 7.2s | 0.4s |
| object file size `-O0 -g` | 4.0M | 767K |
| object file size `-O3` | 1.5M | 553K |
| size of `hexagon_disasm.c` | 5.1M | 2.7M |

Compiler is Apple clang 13.1.6 on M1.