### PR TITLE
Fail safely when too few bytes are provided to disasm

### DIFF
--- a/handwritten/analysis_hexagon_c/functions.c
+++ b/handwritten/analysis_hexagon_c/functions.c
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 RZ_API int hexagon_v6_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *buf, int len, RzAnalysisOpMask mask) {
+	rz_return_val_if_fail(analysis && op && buf, -1);
+	if (len < 4) {
+		return -1;
+	}
 	if (analysis->pcalign == 0) {
 		analysis->pcalign = 0x4;
 	}

--- a/handwritten/asm_hexagon_c/initialization.c
+++ b/handwritten/asm_hexagon_c/initialization.c
@@ -11,6 +11,10 @@
  * \return int Size of the reversed opcode.
  */
 static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int l) {
+	rz_return_val_if_fail(a && op && buf, -1);
+	if (l < 4) {
+		return -1;
+	}
 	ut32 addr = (ut32) a->pc;
 	HexReversedOpcode rev = { .action = HEXAGON_DISAS, .ana_op = NULL, .asm_op = op };
 

--- a/rizin/librz/analysis/p/analysis_hexagon.c
+++ b/rizin/librz/analysis/p/analysis_hexagon.c
@@ -3,7 +3,7 @@
 
 // LLVM commit: 96e220e6886868d6663d966ecc396befffc355e7
 // LLVM commit date: 2022-01-05 11:01:52 +0000 (ISO 8601 format)
-// Date of code generation: 2022-04-02 11:40:33-04:00
+// Date of code generation: 2022-04-17 16:44:52+02:00
 //========================================
 // The following code is generated.
 // Do not edit. Repository of code generator:
@@ -19,6 +19,10 @@
 #include "hexagon_arch.h"
 
 RZ_API int hexagon_v6_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *buf, int len, RzAnalysisOpMask mask) {
+	rz_return_val_if_fail(analysis && op && buf, -1);
+	if (len < 4) {
+		return -1;
+	}
 	if (analysis->pcalign == 0) {
 		analysis->pcalign = 0x4;
 	}

--- a/rizin/librz/asm/p/asm_hexagon.c
+++ b/rizin/librz/asm/p/asm_hexagon.c
@@ -3,7 +3,7 @@
 
 // LLVM commit: 96e220e6886868d6663d966ecc396befffc355e7
 // LLVM commit date: 2022-01-05 11:01:52 +0000 (ISO 8601 format)
-// Date of code generation: 2022-04-02 09:49:53-04:00
+// Date of code generation: 2022-04-17 16:44:52+02:00
 //========================================
 // The following code is generated.
 // Do not edit. Repository of code generator:
@@ -27,6 +27,10 @@
  * \return int Size of the reversed opcode.
  */
 static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int l) {
+	rz_return_val_if_fail(a && op && buf, -1);
+	if (l < 4) {
+		return -1;
+	}
 	ut32 addr = (ut32)a->pc;
 	HexReversedOpcode rev = { .action = HEXAGON_DISAS, .ana_op = NULL, .asm_op = op };
 


### PR DESCRIPTION
This is upstreaming https://github.com/rizinorg/rizin/pull/2507, with two things changed:
* No warning printed, because it's valid usage to call the disassembler with less bytes. It will just not disassemble anything.
* Converted the `librz/asm/p/asm_hexagon.c` one from assert to a real check.

No pr in rizin for this yet, because I have many more changes pending.