### PR TITLE
Disassemble invalid duplex instructions to `invalid ; invalid`.

### DIFF
--- a/handwritten/asm-tests/hexagon
+++ b/handwritten/asm-tests/hexagon
@@ -54,3 +54,5 @@ d "?   R1:0 = S79:78" 00404e6f 0x0
 d "?   R1:0 = combine(##0x1b,#0x3)" 6063017c 0x0
 d "?   if (!P0) R5:4 = memd(R0+R2<<#0x0)" 04c2c031 0x0
 d "?   if (!P0.new) R2 = add(R2,##0x8)" 02618274 0x0
+d "?   invalid" ffffffff 0x0
+d "?   invalid ; invalid" ff3fffff 0x0

--- a/handwritten/hexagon_disas_c/functions.c
+++ b/handwritten/hexagon_disas_c/functions.c
@@ -261,6 +261,27 @@ static void hex_disasm_with_templates(const HexInsnTemplate *tpl, HexState *stat
 	}
 }
 
+/**
+ * \brief Sets a duplex HexInsnContainer and it's sub-instructions to invalid.
+ *
+ * \param hi_u32 The instruction opcode.
+ * \param hic The duplex HexInsnContainer
+ */
+static void hex_set_invalid_duplex(const ut32 hi_u32, RZ_INOUT RZ_NONNULL HexInsnContainer *hic) {
+	HexInsn *hi_high = hic->bin.sub[0];
+	HexInsn *hi_low = hic->bin.sub[1];
+	rz_return_if_fail(hi_high && hi_low);
+	hic->identifier = HEX_INS_INVALID_DECODE;
+	hic->opcode = hi_u32;
+	hi_high->opcode = (hi_u32 >> 16) & 0x1fff;
+	hi_low->opcode = hi_u32 & 0x1fff;
+	hi_high->identifier = HEX_INS_INVALID_DECODE;
+	hi_low->identifier = HEX_INS_INVALID_DECODE;
+	hic->ana_op.type = RZ_ANALYSIS_OP_TYPE_ILL;
+	snprintf(hi_high->text_infix, sizeof(hi_high->text_infix), "invalid");
+	snprintf(hi_low->text_infix, sizeof(hi_low->text_infix), "invalid");
+}
+
 int hexagon_disasm_instruction(HexState *state, const ut32 hi_u32, RZ_INOUT HexInsnContainer *hic, HexPkt *pkt) {
 	ut32 addr = hic->addr;
 	if (hic->pkt_info.last_insn) {
@@ -298,8 +319,15 @@ int hexagon_disasm_instruction(HexState *state, const ut32 hi_u32, RZ_INOUT HexI
 				RZ_LOG_WARN("Reserved duplex instruction class used at: 0x%" PFMT32x ".\n", addr);
 			}
 
-			hex_disasm_with_templates(get_sub_template_table(iclass, true), state, opcode_high, hi_high, hic, addr, pkt);
-			hex_disasm_with_templates(get_sub_template_table(iclass, false), state, opcode_low, hi_low, hic, addr + 2, pkt);
+			const HexInsnTemplate *tmp_high = get_sub_template_table(iclass, true);
+			const HexInsnTemplate *tmp_low = get_sub_template_table(iclass, false);
+			if (!(tmp_high && tmp_low)) {
+				hex_set_invalid_duplex(hi_u32, hic);
+				hex_set_hic_text(hic);
+				return 4;
+			}
+			hex_disasm_with_templates(tmp_high, state, opcode_high, hi_high, hic, addr, pkt);
+			hex_disasm_with_templates(tmp_low, state, opcode_low, hi_low, hic, addr + 2, pkt);
 
 			hic->identifier = (hi_high->identifier << 16) | (hi_low->identifier & 0xffff);
 			hic->ana_op.id = hic->identifier;

--- a/rizin/test/db/asm/hexagon
+++ b/rizin/test/db/asm/hexagon
@@ -54,3 +54,5 @@ d "?   R1:0 = S79:78" 00404e6f 0x0
 d "?   R1:0 = combine(##0x1b,#0x3)" 6063017c 0x0
 d "?   if (!P0) R5:4 = memd(R0+R2<<#0x0)" 04c2c031 0x0
 d "?   if (!P0.new) R2 = add(R2,##0x8)" 02618274 0x0
+d "?   invalid" ffffffff 0x0
+d "?   invalid ; invalid" ff3fffff 0x0


### PR DESCRIPTION
Companion to https://github.com/rizinorg/rizin/pull/2888