### PR TITLE
Add /*<type>*/ comments and fix annotation inconsistencies

### DIFF
--- a/handwritten/hexagon_h/typedefs.h
+++ b/handwritten/hexagon_h/typedefs.h
@@ -127,7 +127,7 @@ typedef struct {
  */
 typedef struct {
     HexPkt pkts[HEXAGON_STATE_PKTS]; // buffered instructions
-    RzList *const_ext_l; // Constant extender values.
+    RzList /*<HexConstExt *>*/ *const_ext_l; // Constant extender values.
 	RzAsm rz_asm; // Copy of RzAsm struct. Holds certain flags of interesed for disassembly formatting.
 	RzConfig *cfg;
 	RzPVector /* RzAsmTokenPattern* */ *token_patterns; ///< PVector with token patterns. Priority ordered.

--- a/rizin/librz/asm/arch/hexagon/hexagon_arch.c
+++ b/rizin/librz/asm/arch/hexagon/hexagon_arch.c
@@ -784,7 +784,7 @@ static inline bool imm_is_scaled(const HexOpAttr attr) {
  * \param addr The address of the instruction which gets the constant extender applied.
  * \return HexConstExt* A const. ext., if there is one which should be applied on the instruction at addr. Otherwise NULL.
  */
-static HexConstExt *get_const_ext_from_addr(const RzList *ce_list, const ut32 addr) {
+static HexConstExt *get_const_ext_from_addr(const RzList /*<HexConstExt *>*/ *ce_list, const ut32 addr) {
 	HexConstExt *ce = NULL;
 	RzListIter *iter = NULL;
 	rz_list_foreach (ce_list, iter, ce) {

--- a/rizin/librz/asm/arch/hexagon/hexagon_arch.h
+++ b/rizin/librz/asm/arch/hexagon/hexagon_arch.h
@@ -66,7 +66,7 @@ RZ_API HexInsn *hexagon_alloc_instr();
 RZ_API void hex_insn_free(RZ_NULLABLE HexInsn *i);
 RZ_API HexInsnContainer *hexagon_alloc_instr_container();
 RZ_API void hex_insn_container_free(RZ_NULLABLE HexInsnContainer *c);
-RZ_API void hex_const_ext_free(HexConstExt *ce);
+RZ_API void hex_const_ext_free(RZ_NULLABLE HexConstExt *ce);
 RZ_API HexState *hexagon_get_state();
 RZ_API void hexagon_reverse_opcode(const RzAsm *rz_asm, HexReversedOpcode *rz_reverse, const ut8 *buf, const ut64 addr);
 RZ_API ut8 hexagon_get_pkt_index_of_addr(const ut32 addr, const HexPkt *p);


### PR DESCRIPTION
I'm trying to add a Rizin CI check to require type comments on certain types (eg. `RzList`, `RzVector`) and enforce annotation consistency ([Rizin PR here](https://github.com/rizinorg/rizin/pull/2986)).

Before this PR, the linter would output:
```
Missing type comment at in line 151 of file /home/runner/work/rizin/rizin/rizin/librz/asm/arch/hexagon/hexagon.h (token is not a comment)
Mismatched function annotation for hex_const_ext_free at in line 69 of file /home/runner/work/rizin/rizin/rizin/librz/asm/arch/hexagon/hexagon_arch.h : None (was RZ_NULLABLE at in line 226 of file /home/runner/work/rizin/rizin/rizin/librz/asm/arch/hexagon/hexagon_arch.c
Missing type comment at in line 787 of file /home/runner/work/rizin/rizin/rizin/librz/asm/arch/hexagon/hexagon_arch.c (token is not a comment)
```